### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,14 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.57</version>
+            <version>1.69</version>
         </dependency>
 
         <!-- Apache HTTP Client -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.13</version>
             <scope>provided</scope>
         </dependency>
 
@@ -64,13 +64,13 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.10</version>
+            <version>7.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.8.47</version>
+            <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/net/klakegg/pkix/ocsp/AbstractOcspClient.java
+++ b/src/main/java/net/klakegg/pkix/ocsp/AbstractOcspClient.java
@@ -5,13 +5,13 @@ import net.klakegg.pkix.ocsp.api.OcspFetcherResponse;
 import net.klakegg.pkix.ocsp.builder.Properties;
 import net.klakegg.pkix.ocsp.builder.Property;
 import net.klakegg.pkix.ocsp.fetcher.UrlOcspFetcher;
+import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.DERTaggedObject;
+import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.X509ObjectIdentifiers;
-import org.bouncycastle.x509.extension.X509ExtensionUtil;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -78,15 +78,15 @@ class AbstractOcspClient {
         }
 
         try {
-            ASN1Sequence asn1Seq = (ASN1Sequence) X509ExtensionUtil.fromExtensionValue(extensionValue);
+            ASN1Sequence asn1Seq = (ASN1Sequence) JcaX509ExtensionUtils.parseExtensionValue(extensionValue);
             Enumeration<?> objects = asn1Seq.getObjects();
 
             while (objects.hasMoreElements()) {
                 ASN1Sequence obj = (ASN1Sequence) objects.nextElement();
                 if (obj.getObjectAt(0).equals(X509ObjectIdentifiers.id_ad_ocsp)) {
-                    DERTaggedObject location = (DERTaggedObject) obj.getObjectAt(1);
+                    ASN1TaggedObject location = (ASN1TaggedObject) obj.getObjectAt(1);
                     if (location.getTagNo() == GeneralName.uniformResourceIdentifier) {
-                        DEROctetString uri = (DEROctetString) location.getObject();
+                        ASN1OctetString uri = (ASN1OctetString) location.getObject();
                         return URI.create(new String(uri.getOctets()));
                     }
                 }


### PR DESCRIPTION
**Changes in pom:**
- Bump bouncycastle and httpclient to newest minor.
- Bump test dependencies to newest major

**Code changes:**
- Cast object to be more generic type to avoid exception on cast (`exception when reading AIA …`). DERTaggedObject -> ASN1TaggedObject.
- Use JcaX509ExtensionUtils.parseExtensionValue in favor of deprecated method